### PR TITLE
Fix failing container bindings

### DIFF
--- a/src/WebauthnServiceProvider.php
+++ b/src/WebauthnServiceProvider.php
@@ -131,9 +131,12 @@ class WebauthnServiceProvider extends PackageServiceProvider
 
         $this->app->bind(
             AttestationObjectLoader::class,
-            fn ($app) => (new AttestationObjectLoader(
-                $app[AttestationStatementSupportManager::class]
-            ))->setLogger($app['log'])
+            function ($app) {
+                $attestationObjectLoader = new AttestationObjectLoader($app[AttestationStatementSupportManager::class]);
+                $attestationObjectLoader->setLogger($app['log']);
+
+                return $attestationObjectLoader;
+            }
         );
 
         $this->app->bind(
@@ -143,24 +146,31 @@ class WebauthnServiceProvider extends PackageServiceProvider
 
         $this->app->bind(
             AuthenticatorAttestationResponseValidator::class,
-            fn ($app) => (new AuthenticatorAttestationResponseValidator(
-                $app[AttestationStatementSupportManager::class],
-                $app[PublicKeyCredentialSourceRepository::class],
-                $app[TokenBindingHandler::class],
-                $app[ExtensionOutputCheckerHandler::class],
-            ))->setLogger($app['log'])
+            function ($app) {
+                $authenticatorAttestationResponseValidator = new AuthenticatorAttestationResponseValidator(
+                    $app[AttestationStatementSupportManager::class],
+                    $app[PublicKeyCredentialSourceRepository::class],
+                    $app[TokenBindingHandler::class],
+                    $app[ExtensionOutputCheckerHandler::class],
+                );
+                $authenticatorAttestationResponseValidator->setLogger($app['log']);
+
+                return $authenticatorAttestationResponseValidator;
+            }
         );
 
-        $this->app->bind(
-            AuthenticatorAssertionResponseValidator::class,
-            fn ($app) => (new AuthenticatorAssertionResponseValidator(
+        $this->app->bind(AuthenticatorAssertionResponseValidator::class, function ($app) {
+            $authenticatorAssertionResponseValidator = new AuthenticatorAssertionResponseValidator(
                 $app[PublicKeyCredentialSourceRepository::class],
                 $app[TokenBindingHandler::class],
                 $app[ExtensionOutputCheckerHandler::class],
-                $app[CoseAlgorithmManager::class]
-            ))->setCounterChecker($app[CounterChecker::class])
-                ->setLogger($app['log'])
-        );
+                $app[CoseAlgorithmManager::class],
+            );
+            $authenticatorAssertionResponseValidator->setCounterChecker($app[CounterChecker::class]);
+            $authenticatorAssertionResponseValidator->setLogger($app['log']);
+
+            return $authenticatorAssertionResponseValidator;
+        });
 
         $this->app->bind(
             AuthenticatorSelectionCriteria::class,
@@ -183,12 +193,12 @@ class WebauthnServiceProvider extends PackageServiceProvider
             )
         );
 
-        $this->app->bind(
-            PublicKeyCredentialLoader::class,
-            fn ($app) => (new PublicKeyCredentialLoader(
-                $app[AttestationObjectLoader::class]
-            ))->setLogger($app['log'])
-        );
+        $this->app->bind(PublicKeyCredentialLoader::class, function ($app) {
+            $publicKeyCredentialLoader = new PublicKeyCredentialLoader($app[AttestationObjectLoader::class]);
+            $publicKeyCredentialLoader->setLogger($app['log']);
+
+            return $publicKeyCredentialLoader;
+        });
 
         $this->app->bind(
             CoseAlgorithmManager::class,

--- a/tests/Services/WebauthnTest.php
+++ b/tests/Services/WebauthnTest.php
@@ -1,9 +1,20 @@
 <?php
 
+use Cose\Algorithm\Manager as CoseAlgorithmManager;
+use Cose\Algorithm\ManagerFactory as CoseAlgorithmManagerFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Rawilk\Webauthn\Models\WebauthnKey;
 use Rawilk\Webauthn\Services\Webauthn;
 use Symfony\Component\Uid\NilUlid;
+use Webauthn\AttestationStatement\AttestationObjectLoader;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\PackedAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\Counter\CounterChecker;
+use Webauthn\PublicKeyCredentialLoader;
+use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\TrustPath\EmptyTrustPath;
 
@@ -61,3 +72,19 @@ it('creates a new WebauthnKey model', function () {
 
     expect($webauthnKey)->toBeInstanceOf(WebauthnKey::class);
 });
+
+it('registers container bindings via closure', function (string $expectedBinding) {
+    expect($this->app[$expectedBinding])->not->toBeNull($expectedBinding);
+})->with([
+    PackedAttestationStatementSupport::class,
+    AttestationStatementSupportManager::class,
+    AttestationObjectLoader::class,
+    CounterChecker::class,
+    AuthenticatorAttestationResponseValidator::class,
+    AuthenticatorAssertionResponseValidator::class,
+    AuthenticatorSelectionCriteria::class,
+    PublicKeyCredentialRpEntity::class,
+    PublicKeyCredentialLoader::class,
+    CoseAlgorithmManager::class,
+    CoseAlgorithmManagerFactory::class,
+]);


### PR DESCRIPTION
Fixes #8 

Hi! I just ran into this problem while upgrading a project to Laravel 10 where I'm using this package. The method signature of `setLogger` in `web-auth/webauthn-lib` changed between v4.4.3 and v4.5.1:
```diff
- public function setLogger(LoggerInterface $logger): self
+ public function setLogger(LoggerInterface $logger): void
```
  
`setLogger` is no longer returning the `self` instance. Therefore the chained calls to `->setLogger` while registering the container bindings causing `null` to be bound to the service container instead.  
  
I created a new test case which verifies that all registered container bindings using a closure to resolve the concrete implementation are not returning null.  
  
Then I fixed the bug by moving the `setLogger` calls to a separate line instead of returning the result directly. In favor of readability I used regular closures for that. However a solution with `tap` and a short closure would work as well, which is also used in other places. So please feel free to change that to your liking 🙂