### PR TITLE
Content Security Policy Support

### DIFF
--- a/src/Support/WebauthnAssets.php
+++ b/src/Support/WebauthnAssets.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rawilk\Webauthn\Support;
 
+use Illuminate\Support\Facades\Vite;
+
 class WebauthnAssets
 {
     public function javaScript(array $options = []): string
@@ -17,15 +19,35 @@ class WebauthnAssets
 
     private function javaScriptAssets(array $options = []): string
     {
-        $appUrl = config('webauthn.asset_url', rtrim($options['asset_url'] ?? '', '/'));
+        $assetsUrl = config('webauthn.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
+        $nonce = $this->getNonce($options);
 
         $manifest = json_decode(file_get_contents(__DIR__ . '/../../dist/mix-manifest.json'), true);
         $versionedFileName = ltrim($manifest['/assets/webauthn.js'], '/');
 
-        $fullAssetPath = "{$appUrl}/webauthn/{$versionedFileName}";
+        $fullAssetPath = "{$assetsUrl}/webauthn/{$versionedFileName}";
 
         return <<<HTML
-        <script src="{$fullAssetPath}" data-turbolinks-eval="false" data-turbo-eval="false"></script>
+        <script src="{$fullAssetPath}" data-turbolinks-eval="false" data-turbo-eval="false" {$nonce}></script>
         HTML;
+    }
+
+    private function getNonce(array $options): string
+    {
+        if (isset($options['nonce'])) {
+            return "nonce=\"{$options['nonce']}\"";
+        }
+
+        // If there is a csp package installed, i.e. spatie/laravel-csp, we'll check for the existence of the helper function.
+        if (function_exists('csp_nonce') && $nonce = csp_nonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        // Lastly, we'll check for the existence of a csp nonce from Vite.
+        if (class_exists(Vite::class) && $nonce = Vite::cspNonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        return '';
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,7 @@ use Webauthn\TrustPath\EmptyTrustPath;
 uses(TestCase::class)->in(
     __DIR__ . '/Models',
     __DIR__ . '/Services',
+    __DIR__ . '/Unit',
 );
 
 // Helpers

--- a/tests/Unit/AssetsDirectiveTest.php
+++ b/tests/Unit/AssetsDirectiveTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\Webauthn\Support\WebauthnAssets;
+
+beforeEach(function () {
+    $this->assets = new WebauthnAssets;
+});
+
+it('outputs the script source', function () {
+    $this->assertStringContainsString(
+        '<script src="/webauthn/assets/webauthn.js?',
+        $this->assets->javaScript(),
+    );
+});
+
+it('outputs a comment when app is in debug mode', function () {
+    config()->set('app.debug', true);
+
+    $this->assertStringContainsString(
+        '<!-- WebAuthn Scripts -->',
+        $this->assets->javaScript(),
+    );
+});
+
+it('does not output a comment when not in debug mode', function () {
+    config()->set('app.debug', false);
+
+    $this->assertStringNotContainsString(
+        '<!-- WebAuthn Scripts -->',
+        $this->assets->javaScript(),
+    );
+});
+
+it('can use a custom asset url', function () {
+    config()->set('webauthn.asset_url', 'https://example.com');
+
+    $this->assertStringContainsString(
+        '<script src="https://example.com/webauthn/assets/webauthn.js?',
+        $this->assets->javaScript(),
+    );
+});
+
+it('accepts an asset url as an argument', function () {
+    $this->assertStringContainsString(
+        '<script src="https://example.com/webauthn/assets/webauthn.js?',
+        $this->assets->javaScript(['asset_url' => 'https://example.com']),
+    );
+});
+
+it('can output a nonce on the script tag', function () {
+    $nonce = Str::random(32);
+
+    $this->assertStringContainsString(
+        "nonce=\"{$nonce}\"",
+        $this->assets->javaScript(['nonce' => $nonce]),
+    );
+});


### PR DESCRIPTION
When implementing a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), a common way to allow script files is to use a nonce. This will allow you to specify a nonce to be rendered onto the package scripts by one of the following ways:

- Send it through as an option via the `@webauthnScripts` blade directive
```html
@webauthnScripts(['nonce' => 'my-nonce'])
```
- Pull in a csp package (such as https://github.com/spatie/laravel-csp)
- Enable `cspNonce` through Vite in a service provider:
```php
Vite::useCspNonce();
```
